### PR TITLE
Chore: config the prettier plugin

### DIFF
--- a/fullstack facebook/.prettierrc
+++ b/fullstack facebook/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/fullstack facebook/package-lock.json
+++ b/fullstack facebook/package-lock.json
@@ -31,6 +31,8 @@
         "eslint-plugin-react-refresh": "^0.4.5",
         "nodemon": "^3.1.4",
         "postcss": "^8.4.41",
+        "prettier": "^3.3.3",
+        "prettier-plugin-tailwindcss": "^0.6.6",
         "tailwindcss": "^3.4.10",
         "typescript": "^5.2.2",
         "vite": "^5.0.8"
@@ -4102,6 +4104,99 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.6.tgz",
+      "integrity": "sha512-OPva5S7WAsPLEsOuOWXATi13QrCKACCiIonFgIR6V4lYv4QLp++UXVhZSzRbZxXGimkQtQT86CC6fQqTOybGng==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig-melody": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig-melody": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -8113,6 +8208,19 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true
+    },
+    "prettier-plugin-tailwindcss": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.6.tgz",
+      "integrity": "sha512-OPva5S7WAsPLEsOuOWXATi13QrCKACCiIonFgIR6V4lYv4QLp++UXVhZSzRbZxXGimkQtQT86CC6fQqTOybGng==",
+      "dev": true,
+      "requires": {}
     },
     "proxy-addr": {
       "version": "2.0.7",

--- a/fullstack facebook/package.json
+++ b/fullstack facebook/package.json
@@ -33,6 +33,8 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "nodemon": "^3.1.4",
     "postcss": "^8.4.41",
+    "prettier": "^3.3.3",
+    "prettier-plugin-tailwindcss": "^0.6.6",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.2.2",
     "vite": "^5.0.8"

--- a/fullstack facebook/src/components/Navbar.tsx
+++ b/fullstack facebook/src/components/Navbar.tsx
@@ -10,7 +10,7 @@ import createPostLogo from "../assets/createPostLogo.png";
 
 const Navbar = () => {
   return (
-    <nav className="p-2 flex  bg-[#FFC123] items-center justify-between">
+    <nav className="flex items-center justify-between bg-[#FFC123] p-2">
       <div className="flex items-center gap-2">
         <img
           src={logo}
@@ -20,13 +20,13 @@ const Navbar = () => {
         <h1 className="text-2xl font-bold">BuZzNet</h1>
       </div>
 
-      <div className="flex gap-5 justify-around flex-grow max-w-xs flex-1 ">
+      <div className="flex max-w-xs flex-1 flex-grow justify-around gap-5">
         <NavItem src={homeLogo} label={"Home"} />
         <NavItem src={groupLogo} label="Group" />
         <NavItem src={createPostLogo} label="Create Post" />
       </div>
 
-      <div className="flex justify-between gap-5 mr-6">
+      <div className="mr-6 flex justify-between gap-5">
         <NavItem src={notificationIcon} label={"Notification"} />
         <NavItem src={profileLogo} label={"Profile"} />
       </div>
@@ -36,7 +36,7 @@ const Navbar = () => {
 export default Navbar;
 
 const NavItem = ({ src, label }: { src: string; label: string }) => (
-  <div className="flex flex-col items-center w-full flex-1 cursor-pointer hover:underline focus:outline-none">
+  <div className="flex w-full flex-1 cursor-pointer flex-col items-center hover:underline focus:outline-none">
     <img src={src} alt={`${label} icon`} className="h-6" />
     <p>{label}</p>
   </div>


### PR DESCRIPTION
Chore: config the prettier plugin
Feat: refactor the class name code automatically by saving the file

I want to config this setup as the [Tailwind docs](!https://tailwindcss.com/docs/editor-setup) recommends this plugin

**The code before**
<img width="639" alt="image" src="https://github.com/user-attachments/assets/a3cc94ac-4ff2-4363-942a-0eec0b14b40e">

**The code after**
<img width="708" alt="image" src="https://github.com/user-attachments/assets/b96a2024-a30a-4f9d-843d-a58f63f80e35">

This is automatically finished by the plugin -> This helps the code is structure in the right way and increase the readabilities